### PR TITLE
feat: 인증상태 enum 추가

### DIFF
--- a/src/main/java/org/supercoding/supertime/service/AuthService.java
+++ b/src/main/java/org/supercoding/supertime/service/AuthService.java
@@ -28,6 +28,7 @@ import org.supercoding.supertime.web.entity.SemesterEntity;
 import org.supercoding.supertime.web.entity.auth.RefreshToken;
 import org.supercoding.supertime.web.entity.board.BoardEntity;
 import org.supercoding.supertime.web.entity.enums.Roles;
+import org.supercoding.supertime.web.entity.enums.Valified;
 import org.supercoding.supertime.web.entity.user.UserEntity;
 import org.supercoding.supertime.web.entity.user.UserProfileEntity;
 
@@ -129,7 +130,7 @@ public class AuthService {
                 .boardList(userBoard)
                 .roles(Roles.ROLE_USER)
                 .isDeleted(0)
-                .varified(0)
+                .valified(Valified.COMPLETED) // 인증에 관한 api 구현 전까지 인증 완료상태 반환
                 .build();
 
         userRepository.save(signupUser);

--- a/src/main/java/org/supercoding/supertime/web/entity/enums/Valified.java
+++ b/src/main/java/org/supercoding/supertime/web/entity/enums/Valified.java
@@ -1,0 +1,14 @@
+package org.supercoding.supertime.web.entity.enums;
+
+public enum Valified {
+    PENDING("PENDING"),
+    DENIED("DENIED"),
+    COMPLETED("COMPLETED"),
+    NEEDED("NEEDED");
+
+    private final String type;
+
+    Valified(String type) {this.type = type;}
+
+    public String getType() {return type;}
+}

--- a/src/main/java/org/supercoding/supertime/web/entity/user/UserEntity.java
+++ b/src/main/java/org/supercoding/supertime/web/entity/user/UserEntity.java
@@ -8,6 +8,7 @@ import org.supercoding.supertime.web.entity.TimeEntity;
 import org.supercoding.supertime.web.entity.board.BoardEntity;
 import org.supercoding.supertime.web.entity.enums.Part;
 import org.supercoding.supertime.web.entity.enums.Roles;
+import org.supercoding.supertime.web.entity.enums.Valified;
 
 import java.util.List;
 
@@ -35,11 +36,6 @@ public class UserEntity extends TimeEntity {
     private Long userProfileCid;
 
     @NotNull
-    @Column(name = "varified")
-    @Schema(description = "사용자 인증 여부(0:비인증, 1:인증)", example = "1")
-    private Integer varified;
-
-    @NotNull
     @Column(name = "user_id")
     @Schema(description = "유저 아이디", example = "id123")
     private String userId;
@@ -63,6 +59,9 @@ public class UserEntity extends TimeEntity {
     @Column(name = "board_cid_list")
     @Schema(name = "게시판 리스트")
     private List<BoardEntity> boardList;
+
+    @Enumerated(EnumType.STRING)
+    private Valified valified;
 
     @Enumerated(EnumType.STRING)
     private Part part;


### PR DESCRIPTION
인증상태를 int의 숫자로 관리하던걸 enum으로 관리하도록 수정하였고, 인증 관련 api가 구현되기 전까지 회원가입시 인증 완료상태로 입력되도록 수정했습니다.